### PR TITLE
0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,13 @@
+## 0.1.2
+ * Removed logging configuration so as to not interfere with higher level
+ logging config.
+ * Added nonzero exit codes when parents or exits are found.
+ * Better JVM interop - specifically, superior handling for `defprotocol`,
+ `deftype` and `defrecord` forms.
+
+## 0.1.1
+ * Fixed a dependency bug that caused Yagni to point at a snapshot rather 
+ than the current release.
+
 ## 0.1.0
  * Initial release with form-walking, graph search.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ graph's search.
 Merge the following into your `~/.lein/profiles.clj`:
 
 ```clojure
-{:user {:plugins [[venantius/yagni "0.1.1"]]}}
+{:user {:plugins [[venantius/yagni "0.1.2"]]}}
 ```
 
 ## Usage

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,6 @@
                  [org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.analyzer.jvm "0.6.7"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [org.clojure/tools.namespace "0.2.10"]
+                 [org.clojure/tools.namespace "0.2.11"]
                  [org.slf4j/slf4j-log4j12 "1.7.12"]]
   :eval-in-leiningen true)

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,6 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[im.chit/hara.class "2.1.8"]
                  [org.clojure/clojure "1.6.0"]
-                 [org.clojure/tools.analyzer.jvm "0.6.7"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.clojure/tools.namespace "0.2.11"]
                  [org.slf4j/slf4j-log4j12 "1.7.12"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject venantius/yagni "0.1.2-SNAPSHOT"
+(defproject venantius/yagni "0.1.2"
   :description "A Leiningen plugin for finding dead code."
   :url "https://github.com/venantius/yagni"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,10 @@
-(defproject venantius/yagni "0.1.1"
+(defproject venantius/yagni "0.1.2-SNAPSHOT"
   :description "A Leiningen plugin for finding dead code."
   :url "https://github.com/venantius/yagni"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[im.chit/hara.class "2.1.8"]
+                 [org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.analyzer.jvm "0.6.7"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.clojure/tools.namespace "0.2.10"]

--- a/src/leiningen/yagni.clj
+++ b/src/leiningen/yagni.clj
@@ -7,7 +7,7 @@
    walker."
   [project & args]
   (let [opts (select-keys project [:source-paths :yagni :main])
-        deps {:dependencies [['venantius/yagni "0.1.1"]]}]
+        deps {:dependencies [['venantius/yagni "0.1.2-SNAPSHOT"]]}]
     (eval-in-project
       (merge-profiles project [deps])
       `(yagni.core/run-yagni '~opts)

--- a/src/log4j.properties
+++ b/src/log4j.properties
@@ -1,9 +1,0 @@
-# Root logger option
-log4j.rootLogger=INFO, stdout
-log4j.logger.com.mchange.v2=FATAL
- 
-# Direct log messages to stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%p | %d{MM-dd-yyyy HH:mm:ss} | %c | %m%n

--- a/src/yagni/core.clj
+++ b/src/yagni/core.clj
@@ -19,7 +19,7 @@
   "Merge the main method (if it exists) with any entrypoints from the
    `.lein-yagni` file (if it exists)."
   [main]
-  (into [] (concat 
+  (into [] (concat
             (load-entrypoints)
             (when main [(symbol (str main) "-main")]))))
 
@@ -27,12 +27,12 @@
   "Main Yagni function.
 
    Yagni works by keeping track of all interned vars defined in a project's
-   :source-paths directories' namespaces, and then macroexpanding all the 
+   :source-paths directories' namespaces, and then macroexpanding all the
    forms in those namespaces to see where those are actually used.
 
    As it walks the forms, it builds a graph of var references. Once it's done
-   building the graph, it searches the graph and emits warnings for nodes 
-   (vars) that weren't reachable from a search of entry points. By default, 
+   building the graph, it searches the graph and emits warnings for nodes
+   (vars) that weren't reachable from a search of entry points. By default,
    the only entry point is the project's `:main` method, but additional entry
    points can be specified in a `.lein-yagni` file at the root directory of
    the project."
@@ -42,9 +42,10 @@
     (namesp/prepare-namespaces namespaces)
     (let [graph (atom (namesp/named-vars-map namespaces))
           generator-fns (jvm/find-generator-fns graph)]
-      (jvm/extend-graph-for-java! graph generator-fns)
+      (jvm/extend-generators! graph generator-fns)
       (form/count-vars graph namespaces)
       (graph/prune-findable-nodes! graph entrypoints (atom #{}))
+      (jvm/compress-generators! graph generator-fns)
       (let [has-unused-vars? (report graph)]
         (shutdown-agents)
         (when has-unused-vars?

--- a/src/yagni/core.clj
+++ b/src/yagni/core.clj
@@ -43,5 +43,7 @@
     (swap! graph merge (named-vars-map namespaces))
     (count-vars namespaces)
     (prune-findable-nodes! graph entrypoints found-nodes)
-    (report graph)
-    (shutdown-agents)))
+    (let [has-unused-vars? (report graph)]
+      (shutdown-agents)
+      (when has-unused-vars?
+        (System/exit 1)))))

--- a/src/yagni/jvm.clj
+++ b/src/yagni/jvm.clj
@@ -1,0 +1,67 @@
+(ns yagni.jvm
+  "Utility functions for working with the JVM."
+  (:require [clojure.string :as string]))
+
+(defn class-name->var-name
+  "Return the var name for the given class name.
+
+   Note that this makes NO assumptions about whether or not the class in
+   question actually has an associated var.
+
+   For reference, `defprotocol` does intern such a var, but `deftype` and
+   `defrecord` do not (they only intern generator functions).
+
+   E.g. let's assume we've got a namespace foo with (defprotocol bar ...) and
+   (deftype baz [] bar ...). Macroexpanding baz will substitute foo.bar for
+   foo/bar and will point to the associated compiled JVM bytecode."
+  {:added "0.1.2"}
+  [v]
+  (let [c (-> v str (string/split #" ") second (string/split #"\."))
+        n (string/replace (string/join "." (take (- (count c) 1) c)) "_" "-")
+        v (last c)]
+    (symbol n v)))
+
+(defn var-name->class-name
+  "Given a var name, try to find the equivalent class name."
+  [v]
+  (let [v (-> v str (string/split #"/"))
+        n (string/replace (first v) "-" "_")
+        c (last v)]
+    (symbol (string/join "." [n c]))))
+
+(defn is-class-generator?
+  "Check to see if a given var is a class generator. If it is, returns the
+   Java class for the generator in question.
+   
+   This function is intended for dealing with the class generator functions 
+   that are interned by `deftype` and `defrecord` declarations."
+  [v]
+  (let [v (resolve v)
+        n (str (:ns (meta v)))
+        name (str (:name (meta v)))]
+    (or
+      (and 
+        (.startsWith name "->")
+        (resolve (var-name->class-name (symbol n (subs name 2)))))
+      (and 
+        (.startsWith name "map->")
+        (resolve (var-name->class-name (symbol n (subs name 5))))))))
+
+(defn find-generator-fns
+  [g]
+  (into #{} (filter is-class-generator? (keys @g))))
+
+(defn extend-graph-for-java!
+  "Given generator functions, add nodes for the corresponding `deftype` or
+   `defrecord` and add edges from the generator functions to those
+   nodes.
+   
+   It's worth noting that `deftype` and `defrecord` forms don't intern
+   vars for themselves (just their generators). The fact that we add nodes
+   for them is an exception to the normal mode of operation here."
+  [g fns]
+  (doseq [f fns]
+    (when-let [v (class-name->var-name
+                   (is-class-generator? f))]
+      (swap! g assoc v #{})
+      (swap! g update-in [f] conj v))))

--- a/src/yagni/namespace.clj
+++ b/src/yagni/namespace.clj
@@ -15,12 +15,12 @@
 
 (defn var-name
   "Return the fully qualified name of the corresponding var.
-   
+
    Includes checks for things like interfaces, which may exist as Clojure vars
    but must be checked "
   [v]
   (cond
-    (and (class? v) (interface? v))
+    (class? v)
     (jvm/class-name->var-name v)
     :else
     (symbol (str (:ns (meta v)))

--- a/src/yagni/namespace.clj
+++ b/src/yagni/namespace.clj
@@ -1,5 +1,7 @@
 (ns yagni.namespace
-  "Functions for working with namespaces")
+  "Functions for working with namespaces"
+  (:require [clojure.string :as string]
+            [hara.class :refer [interface?]]))
 
 (defn prepare-namespaces
   "First, create all of our namespaces so that we dont' have to worry about
@@ -10,11 +12,34 @@
   (doseq [n namespaces]
     (require n :reload)))
 
-(defn var-name
-  "Return the fully qualified name of the corresponding var."
+(defn interface->var-name
+  "Return the var name for the given interface, assuming one exists.
+
+   E.g. let's assume we've got a namespace foo with (defprotocol bar ...) and
+   (deftype baz [] bar ...). Macroexpanding baz will substitute foo.bar for
+   foo/bar and will point to the associated compiled JVM bytecode.
+   
+   If the var in question cannot be found (i.e. corresponds to native Java
+   code), return nil."
+  {:added "0.1.2"}
   [v]
-  (symbol (str (:ns (meta v)))
-          (str (:name (meta v)))))
+  (let [c (-> v str (string/split #" ") second (string/split #"\."))
+        n (string/replace (string/join "." (take (- (count c) 1) c)) "_" "-")
+        v (last c)]
+    (symbol n v)))
+
+(defn var-name
+  "Return the fully qualified name of the corresponding var.
+   
+   Includes checks for things like interfaces, which may exist as Clojure vars
+   but must be checked "
+  [v]
+  (cond
+    (and (class? v) (interface? v))
+    (interface->var-name v)
+    :else
+    (symbol (str (:ns (meta v)))
+            (str (:name (meta v))))))
 
 (defn qualified-interns
   "Return a seq of fully qualified namespace symbols"

--- a/src/yagni/namespace.clj
+++ b/src/yagni/namespace.clj
@@ -1,7 +1,8 @@
 (ns yagni.namespace
   "Functions for working with namespaces"
   (:require [clojure.string :as string]
-            [hara.class :refer [interface?]]))
+            [hara.class :refer [interface?]]
+            [yagni.jvm :as jvm]))
 
 (defn prepare-namespaces
   "First, create all of our namespaces so that we dont' have to worry about
@@ -12,22 +13,6 @@
   (doseq [n namespaces]
     (require n :reload)))
 
-(defn interface->var-name
-  "Return the var name for the given interface, assuming one exists.
-
-   E.g. let's assume we've got a namespace foo with (defprotocol bar ...) and
-   (deftype baz [] bar ...). Macroexpanding baz will substitute foo.bar for
-   foo/bar and will point to the associated compiled JVM bytecode.
-   
-   If the var in question cannot be found (i.e. corresponds to native Java
-   code), return nil."
-  {:added "0.1.2"}
-  [v]
-  (let [c (-> v str (string/split #" ") second (string/split #"\."))
-        n (string/replace (string/join "." (take (- (count c) 1) c)) "_" "-")
-        v (last c)]
-    (symbol n v)))
-
 (defn var-name
   "Return the fully qualified name of the corresponding var.
    
@@ -36,7 +21,7 @@
   [v]
   (cond
     (and (class? v) (interface? v))
-    (interface->var-name v)
+    (jvm/class-name->var-name v)
     :else
     (symbol (str (:ns (meta v)))
             (str (:name (meta v))))))

--- a/src/yagni/namespace/form.clj
+++ b/src/yagni/namespace/form.clj
@@ -3,8 +3,6 @@
             [yagni.namespace :refer [qualified-interns
                                      var-name]]))
 
-(def graph (atom {}))
-
 (defn get-form
   "Retrieve the form for the underlying symbol"
   [s]
@@ -26,25 +24,25 @@
   "Take a look at the form. If it's a symbol that can be resolved to a var 
    and exists as a node in our graph, then add an outgoing edge from the
    sym to this var."
-  [sym form]
+  [graph sym form]
   (when (symbol? form)
     (when-let [form-var (try-to-resolve form)]
       (let [v (var-name form-var)]
         (when (and
-                (get @graph v)
-                (not= v sym))
+               (get @graph v)
+               (not= v sym))
           (swap! graph update-in [sym] conj v))))))
 
 (defn walk-form-body
   "Walk the form."
-  [{:keys [form sym]}]
+  [graph {:keys [form sym]}]
   (if (or (seq? form) (coll? form))
     (when (seq form)
-      (walk-form-body {:form (first form)
-                       :sym sym})
-      (walk-form-body {:form (rest form)
-                       :sym sym}))
-    (maybe-inc sym form)))
+      (walk-form-body graph {:form (macroexpand-1 (first form))
+                             :sym sym})
+      (walk-form-body graph {:form (rest form)
+                             :sym sym}))
+    (maybe-inc graph sym form)))
 
 (defn macroexpand-source
   "While keeping track of the symbol whose form we're exploring, macroexpand
@@ -55,13 +53,14 @@
 
 (defn count-vars-in-ns
   "Count the functions in a single ns."
-  [n]
+  [g n]
   (let [interns (qualified-interns n)
         forms (map get-form interns)]
     (in-ns n)
-    (doall (map walk-form-body (map macroexpand-source forms)))))
+    (doall (map println (map macroexpand forms)))
+    (doall (map (partial walk-form-body g) (map macroexpand-source forms)))))
 
 (defn count-vars
   "Count the functions in all namespaces."
-  [namespaces]
-  (doall (map count-vars-in-ns namespaces)))
+  [graph namespaces]
+  (doall (map (partial count-vars-in-ns graph) namespaces)))

--- a/src/yagni/reporter.clj
+++ b/src/yagni/reporter.clj
@@ -12,10 +12,10 @@
        (str
         "=================== WARNING: Parents ======================\n"
         "==    Could not find any references to the following     ==\n"
-        "===========================================================\n"))  
+        "===========================================================\n"))
       (doall (map println parents)))
     (when (not-empty children)
-      (println 
+      (println
        (str
         "\n"
         "================== WARNING: Children ======================\n"

--- a/src/yagni/reporter.clj
+++ b/src/yagni/reporter.clj
@@ -1,5 +1,6 @@
 (ns yagni.reporter
   (:require [clojure.tools.logging :as log]
+            [yagni.jvm :as jvm]
             [yagni.graph :as graph]))
 
 (defn report
@@ -10,7 +11,7 @@
       (println
        (str
         "=================== WARNING: Parents ======================\n"
-        "== Could not find any references to the following vars. ===\n"
+        "==    Could not find any references to the following     ==\n"
         "===========================================================\n"))  
       (doall (map println parents)))
     (when (not-empty children)
@@ -18,8 +19,8 @@
        (str
         "\n"
         "================== WARNING: Children ======================\n"
-        "== The following vars have references to them, but their ==\n"
-        "== parents do not.                                       ==\n"
+        "==   The following have references to them, but their    ==\n"
+        "==   parents do not.                                     ==\n"
         "===========================================================\n"))
       (doall (map println children)))
     (or (not-empty parents) (not-empty children))))

--- a/src/yagni/reporter.clj
+++ b/src/yagni/reporter.clj
@@ -21,4 +21,5 @@
         "== The following vars have references to them, but their ==\n"
         "== parents do not.                                       ==\n"
         "===========================================================\n"))
-      (doall (map println children)))))
+      (doall (map println children)))
+    (or (not-empty parents) (not-empty children))))

--- a/test/yagni/jvm_test.clj
+++ b/test/yagni/jvm_test.clj
@@ -1,0 +1,26 @@
+(ns yagni.jvm-test
+  (:require [clojure.test :refer :all]
+            [yagni.jvm :as jvm]))
+
+(defprotocol Foo
+  (bar [this]))
+
+(deftype FooType []
+  Foo
+  (bar [this] true))
+
+(defrecord FooRecord [bar baz])
+
+(deftest var-name->class-name-works
+  (is (= (jvm/var-name->class-name 
+           'yagni-test.datatypes/UnusedTypeImplementingUsedProtocol)
+         'yagni_test.datatypes.UnusedTypeImplementingUsedProtocol)))
+
+(deftest is-class-generator?-works
+  (is (some? (jvm/is-class-generator? 'yagni.jvm-test/->FooType)))
+  (is (some? (jvm/is-class-generator? 'yagni.jvm-test/->FooRecord)))
+  (is (some? (jvm/is-class-generator? 'yagni.jvm-test/map->FooRecord)))) 
+
+(deftest find-generator-fns-works
+  (is (= ['yagni.jvm-test/->FooType]
+         (jvm/find-generator-fns (atom {'yagni.jvm-test/->FooType #{}})))))

--- a/test/yagni/jvm_test.clj
+++ b/test/yagni/jvm_test.clj
@@ -11,16 +11,23 @@
 
 (defrecord FooRecord [bar baz])
 
+(defprotocol SampleInterface
+  (foo [this]))
+
+(deftest class-name->var-name
+  (is (= (jvm/class-name->var-name yagni.jvm_test.SampleInterface)
+         'yagni.jvm-test/SampleInterface)))
+
 (deftest var-name->class-name-works
-  (is (= (jvm/var-name->class-name 
-           'yagni-test.datatypes/UnusedTypeImplementingUsedProtocol)
+  (is (= (jvm/var-name->class-name
+          'yagni-test.datatypes/UnusedTypeImplementingUsedProtocol)
          'yagni_test.datatypes.UnusedTypeImplementingUsedProtocol)))
 
 (deftest is-class-generator?-works
   (is (some? (jvm/is-class-generator? 'yagni.jvm-test/->FooType)))
   (is (some? (jvm/is-class-generator? 'yagni.jvm-test/->FooRecord)))
-  (is (some? (jvm/is-class-generator? 'yagni.jvm-test/map->FooRecord)))) 
+  (is (some? (jvm/is-class-generator? 'yagni.jvm-test/map->FooRecord))))
 
 (deftest find-generator-fns-works
-  (is (= ['yagni.jvm-test/->FooType]
+  (is (= #{'yagni.jvm-test/->FooType}
          (jvm/find-generator-fns (atom {'yagni.jvm-test/->FooType #{}})))))

--- a/test/yagni/namespace/form_test.clj
+++ b/test/yagni/namespace/form_test.clj
@@ -6,9 +6,9 @@
 (deftest get-form-works
   (is (= (form/get-form 'clojure.core/conj)
          '{:source (def conj
-            (fn conj ([coll x] (. clojure.lang.RT (conj coll x)))
-              ([coll x & xs]
-               (if xs (recur (conj coll x) (first xs) (next xs)) (conj coll x)))))
+                     (fn conj ([coll x] (. clojure.lang.RT (conj coll x)))
+                       ([coll x & xs]
+                        (if xs (recur (conj coll x) (first xs) (next xs)) (conj coll x)))))
            :sym clojure.core/conj})))
 
 (deftest try-to-resolve-works
@@ -18,16 +18,16 @@
          nil)))
 
 (deftest maybe-inc-works
-  (with-redefs [form/graph (atom {'clojure.core/conj #{}
-                                  'clojure.core/bananas #{}})] 
-    (form/maybe-inc 'clojure.core/bananas 'conj)
-    (is (= @form/graph {'clojure.core/conj #{}
-                        'clojure.core/bananas #{'clojure.core/conj}}))))
+  (let [graph (atom {'clojure.core/conj #{}
+                     'clojure.core/bananas #{}})] 
+    (form/maybe-inc graph 'clojure.core/bananas 'conj)
+    (is (= @graph {'clojure.core/conj #{}
+                   'clojure.core/bananas #{'clojure.core/conj}}))))
 
 (deftest count-vars-works
-  (with-redefs [form/graph (atom {'yagni.sample-ns/y #{}
-                                  'yagni.sample-ns/x #{}})] 
-    (form/count-vars ['yagni.sample-ns])
-    (is (= @form/graph
+  (let [graph (atom {'yagni.sample-ns/y #{}
+                     'yagni.sample-ns/x #{}})] 
+    (form/count-vars graph ['yagni.sample-ns])
+    (is (= @graph
            {'yagni.sample-ns/y #{'yagni.sample-ns/x}
             'yagni.sample-ns/x #{}}))))

--- a/test/yagni/namespace_test.clj
+++ b/test/yagni/namespace_test.clj
@@ -5,6 +5,13 @@
 
 (def x "sample var")
 
+(defprotocol SampleInterface
+  (foo [this]))
+
+(deftest interface->var-name-works
+  (is (= (namesp/interface->var-name yagni.namespace_test.SampleInterface)
+         'yagni.namespace-test/SampleInterface)))
+
 (deftest var-name-works
   (is (= (namesp/var-name (var x))
          'yagni.namespace-test/x)))

--- a/test/yagni/namespace_test.clj
+++ b/test/yagni/namespace_test.clj
@@ -5,13 +5,6 @@
 
 (def x "sample var")
 
-(defprotocol SampleInterface
-  (foo [this]))
-
-(deftest interface->var-name-works
-  (is (= (namesp/interface->var-name yagni.namespace_test.SampleInterface)
-         'yagni.namespace-test/SampleInterface)))
-
 (deftest var-name-works
   (is (= (namesp/var-name (var x))
          'yagni.namespace-test/x)))
@@ -19,9 +12,9 @@
 (deftest qualified-interns-works
   (is (= (namesp/qualified-interns 'yagni.sample-ns)
          '(yagni.sample-ns/y
-            yagni.sample-ns/x))))
+           yagni.sample-ns/x))))
 
 (deftest named-vars-map-works
-  (is (= (namesp/named-vars-map ['yagni.sample-ns]) 
+  (is (= (namesp/named-vars-map ['yagni.sample-ns])
          {'yagni.sample-ns/y #{}
           'yagni.sample-ns/x #{}})))


### PR DESCRIPTION
Another note in addition to the commit message on https://github.com/venantius/yagni/commit/65b02f447a2cf313b058e892c9b076ad25388883: after searching the graph for findable nodes, Yagni collapses the graph by removing the nodes for generator functions and redirecting anything that was pointing at them directly at the var-like nodes for the `deftype`, `defrecord` forms, etc.

Resolves #23 
Resolves #21 
Resolves #19 
Resolves #18 